### PR TITLE
Bug al responder por controlador las llamadas ajax de los documentos al cambiar el estado

### DIFF
--- a/Core/Lib/AjaxForms/PurchasesController.php
+++ b/Core/Lib/AjaxForms/PurchasesController.php
@@ -351,7 +351,7 @@ abstract class PurchasesController extends PanelController
         return false;
     }
 
-    protected function saveDocAction(): bool
+    protected function saveDocAction(bool $sendOk = true): bool
     {
         $this->setTemplate(false);
 
@@ -403,7 +403,10 @@ abstract class PurchasesController extends PanelController
             return false;
         }
 
-        $this->sendJsonWithLogs(['ok' => true, 'newurl' => $model->url() . '&action=save-ok']);
+        if ($sendOk) {
+            $this->sendJsonWithLogs(['ok' => true, 'newurl' => $model->url() . '&action=save-ok']);
+        }
+
         $this->dataBase->commit();
         return true;
     }
@@ -476,7 +479,7 @@ abstract class PurchasesController extends PanelController
             return false;
         }
 
-        if ($this->getModel()->editable && false === $this->saveDocAction()) {
+        if ($this->getModel()->editable && false === $this->saveDocAction(false)) {
             return false;
         }
 

--- a/Core/Lib/AjaxForms/SalesController.php
+++ b/Core/Lib/AjaxForms/SalesController.php
@@ -366,7 +366,7 @@ abstract class SalesController extends PanelController
         return false;
     }
 
-    protected function saveDocAction(): bool
+    protected function saveDocAction(bool $sendOk = true): bool
     {
         $this->setTemplate(false);
 
@@ -418,7 +418,10 @@ abstract class SalesController extends PanelController
             return false;
         }
 
-        $this->sendJsonWithLogs(['ok' => true, 'newurl' => $model->url() . '&action=save-ok']);
+        if ($sendOk) {
+            $this->sendJsonWithLogs(['ok' => true, 'newurl' => $model->url() . '&action=save-ok']);
+        }
+
         $this->dataBase->commit();
         return true;
     }
@@ -490,7 +493,7 @@ abstract class SalesController extends PanelController
             return false;
         }
 
-        if ($this->getModel()->editable && false === $this->saveDocAction()) {
+        if ($this->getModel()->editable && false === $this->saveDocAction(false)) {
             return false;
         }
 


### PR DESCRIPTION
Cuando se cambia el estado de un documento antes de nada guarda el documento y eso hace que la devolución json ya se ejecute, de tal forma que luego al cambiar el estado si una extensión como verifactu quiere devolver false, el estado no se cambia que es lo esperado, pero no muestra los mensajes de error de porque no.

## ¿Cómo has probado los cambios?
Toda modificación debe haber sido mínimamente probada. Marca o describe las pruebas que has realizado:
- [x] He revisado mi código antes de enviarlo.
- [x] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.